### PR TITLE
Refactor inbox to display conversations with two-pane layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -573,7 +573,113 @@ footer {
   cursor: default;
 }
 
-/* Responsive tweaks */
+/* New Inbox Layout Styles */
+#inbox-layout {
+  display: flex;
+  gap: calc(var(--spacing) * 2);
+  margin-top: calc(var(--spacing) * 2);
+  border-top: 1px solid var(--divider);
+  padding-top: calc(var(--spacing) * 2);
+}
+
+#conversation-list-pane {
+  flex: 1;
+  min-width: 250px; /* Minimum width for the list pane */
+  max-width: 350px; /* Maximum width for the list pane */
+  border-right: 1px solid var(--divider);
+  padding-right: var(--spacing);
+  max-height: 70vh; /* Limit height and make it scrollable */
+  overflow-y: auto;
+}
+
+#conversation-list-pane h2 {
+  font-family: var(--font-nav);
+  margin-bottom: var(--spacing);
+  color: var(--color-text);
+  font-size: 1.5rem;
+}
+
+#conversation-list-items .conversation-list-item {
+  padding: var(--spacing);
+  margin-bottom: var(--spacing);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color var(--transition);
+  border: 1px solid transparent; /* For smooth transition with active state */
+}
+
+#conversation-list-items .conversation-list-item:hover {
+  background-color: var(--color-feature-bg);
+}
+
+#conversation-list-items .conversation-list-item.active {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  border-color: var(--color-secondary);
+}
+
+#conversation-view-pane {
+  flex: 2; /* Takes more space */
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh; /* Limit height to align with list pane */
+}
+
+#conversation-placeholder {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 1.1rem;
+  margin: auto; /* Center placeholder text */
+}
+
+#conversation-header h3 {
+  font-family: var(--font-nav);
+  font-size: 1.5rem;
+  color: var(--color-text);
+  margin-bottom: var(--spacing);
+  padding-bottom: var(--spacing);
+  border-bottom: 1px solid var(--divider);
+}
+
+#message-display-area {
+  flex-grow: 1; /* Allows this area to take up available space */
+  overflow-y: auto;
+  padding: var(--spacing) 0; /* Add some padding */
+  margin-bottom: var(--spacing);
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing) / 2);
+}
+
+/* Ensure message-in and message-out take full width of their container if needed, but align self correctly */
+#message-display-area .message-in,
+#message-display-area .message-out {
+  padding: calc(var(--spacing) * 0.75) var(--spacing); /* Slightly adjust padding */
+  /* max-width is already set in general styles, which is good */
+}
+
+#reply-form {
+  margin-top: auto; /* Pushes reply form to the bottom if space is available */
+  border-top: 1px solid var(--divider);
+  padding-top: var(--spacing);
+}
+
+/* Responsive tweaks for Inbox */
+@media (max-width: 768px) {
+  #inbox-layout {
+    flex-direction: column;
+  }
+  #conversation-list-pane {
+    max-width: 100%;
+    border-right: none;
+    margin-bottom: var(--spacing);
+    max-height: 40vh; /* Adjust height for column layout */
+  }
+  #conversation-view-pane {
+     max-height: 50vh; /* Adjust height for column layout */
+  }
+}
+
 @media (max-width: 480px) {
   .content-wrapper {
     padding: 0 var(--spacing);

--- a/inbox.html
+++ b/inbox.html
@@ -36,8 +36,27 @@
 
     <hr class="inbox-separator" />
 
-    <!-- Inbox List -->
-    <section id="inbox-list" class="inbox-list"></section>
+    <!-- Inbox Layout: Conversation List and Selected Conversation View -->
+    <div id="inbox-layout">
+      <div id="conversation-list-pane">
+        <h2>Conversations</h2>
+        <div id="conversation-list-items">
+          <!-- Conversation items will be populated by JS -->
+        </div>
+      </div>
+      <div id="conversation-view-pane">
+        <!-- Selected conversation messages and reply form will appear here -->
+        <p id="conversation-placeholder">Select a conversation to view messages or compose a new message above to start a new chat.</p>
+        <div id="conversation-header"></div>
+        <div id="message-display-area"></div>
+        <form id="reply-form" class="compose-form" style="display: none;">
+          <textarea id="reply-content" rows="3" maxlength="500" required placeholder="Type your reply…"></textarea>
+          <button type="submit" class="submit-button">Send Reply</button>
+          <div id="reply-error" class="error"></div>
+          <div id="reply-success" class="success"></div>
+        </form>
+      </div>
+    </div>
   </main>
 
   <div id="footer-placeholder"></div>

--- a/js/inbox.js
+++ b/js/inbox.js
@@ -1,77 +1,118 @@
 // js/inbox.js
 document.addEventListener('DOMContentLoaded', async () => {
-  const listEl    = document.getElementById('inbox-list');
-  const form      = document.getElementById('compose-form');
-  const recipient = document.getElementById('recipient-select');
-  const content   = document.getElementById('compose-content');
-  const errEl     = document.getElementById('compose-error');
-  const okEl      = document.getElementById('compose-success');
+  // Main compose form (for new conversations)
+  const composeForm        = document.getElementById('compose-form');
+  const recipientSelect    = document.getElementById('recipient-select');
+  const composeContent     = document.getElementById('compose-content');
+  const composeErrorEl     = document.getElementById('compose-error');
+  const composeSuccessEl   = document.getElementById('compose-success');
 
-  // 1) Load users into the recipient dropdown
+  // Conversation display elements
+  const conversationListItemsEl = document.getElementById('conversation-list-items');
+  const conversationPlaceholder = document.getElementById('conversation-placeholder');
+  const conversationHeaderEl    = document.getElementById('conversation-header');
+  const messageDisplayAreaEl  = document.getElementById('message-display-area');
+
+  // Reply form (for existing conversations)
+  const replyForm           = document.getElementById('reply-form');
+  const replyContent        = document.getElementById('reply-content');
+  const replyErrorEl        = document.getElementById('reply-error');
+  const replySuccessEl      = document.getElementById('reply-success');
+
+  let currentPartnerId    = null;
+  let currentPartnerName  = null;
+  let allUsers            = []; // To store user data for easy lookup
+
+  // 1) Load users into the main recipient dropdown and store them
   try {
     const users = await fetch('/api/users', { credentials: 'include' }).then(r => r.json());
+    allUsers = users; // Store for later use
     users.forEach(u => {
       const opt = document.createElement('option');
       opt.value = u.id;
       opt.textContent = u.username;
-      recipient.append(opt);
+      recipientSelect.append(opt);
     });
   } catch {
-    recipient.innerHTML = '<option disabled>Failed to load users</option>';
+    recipientSelect.innerHTML = '<option disabled>Failed to load users</option>';
   }
 
-  // 2) Fetch & render inbox messages
-  async function loadInbox() {
-    listEl.innerHTML = '';
+  // 2) Fetch & render conversation partners
+  async function loadConversationPartners() {
+    conversationListItemsEl.innerHTML = ''; // Clear previous list
     try {
-      const msgs = await fetch('/api/messages/inbox', { credentials: 'include' }).then(r => r.json());
-      if (msgs.length === 0) {
-        listEl.textContent = 'No messages.';
+      const partners = await fetch('/api/conversations', { credentials: 'include' }).then(r => r.json());
+      if (partners.length === 0) {
+        const p = document.createElement('p');
+        p.textContent = 'No active conversations. Compose a message to start one!';
+        conversationListItemsEl.appendChild(p);
         return;
       }
-      msgs.forEach(msg => {
-        const card = document.createElement('div');
-        card.className = 'feature-card';
-        card.innerHTML = `
-          <div style="display:flex; justify-content:space-between;">
-            <strong>From: ${msg.sender}</strong>
-            <small>${new Date(msg.created_at).toLocaleString()}</small>
-          </div>
-          <p>${msg.content}</p>
-          <button data-id="${msg.id}" class="mark-read-button" ${msg.is_read ? 'disabled' : ''}>
-            ${msg.is_read ? 'Read' : 'Mark as read'}
-          </button>
-        `;
-        listEl.appendChild(card);
+      partners.forEach(partner => {
+        const item = document.createElement('div');
+        item.className = 'conversation-list-item feature-card'; // Re-use feature-card styling for items
+        item.textContent = `Chat with ${partner.username}`;
+        item.dataset.partnerId = partner.id;
+        item.dataset.partnerName = partner.username;
+        item.addEventListener('click', () => selectConversation(partner.id, partner.username));
+        conversationListItemsEl.appendChild(item);
       });
-    } catch {
-      listEl.textContent = 'Failed to load your inbox.';
+    } catch (err) {
+      console.error('Failed to load conversation partners:', err);
+      conversationListItemsEl.innerHTML = '<p>Error loading conversations.</p>';
     }
   }
 
-  listEl.addEventListener('click', async e => {
-    if (!e.target.matches('.mark-read-button')) return;
-    const btn = e.target, id = btn.dataset.id;
-    await fetch(`/api/messages/${id}/read`, {
-      method: 'POST',
-      credentials: 'include'
+  // 3) Handle selecting a conversation
+  async function selectConversation(partnerId, partnerName) {
+    currentPartnerId = partnerId;
+    currentPartnerName = partnerName;
+
+    conversationPlaceholder.style.display = 'none';
+    messageDisplayAreaEl.innerHTML = ''; // Clear previous messages
+    conversationHeaderEl.innerHTML = `<h3>Chat with ${partnerName}</h3>`;
+    replyForm.style.display = 'flex'; // Show reply form
+
+    // Highlight selected partner
+    document.querySelectorAll('.conversation-list-item').forEach(item => {
+        item.classList.toggle('active', item.dataset.partnerId === partnerId);
     });
-    btn.textContent = 'Read';
-    btn.disabled = true;
-  });
 
-  await loadInbox();
+    try {
+      const messages = await fetch(`/api/messages/thread/${partnerId}`, { credentials: 'include' }).then(r => r.json());
+      if (messages.length === 0) {
+        messageDisplayAreaEl.innerHTML = '<p>No messages yet in this conversation.</p>';
+      } else {
+        messages.forEach(msg => {
+          const div = document.createElement('div');
+          // Note: The API returns sender_id. If message sender_id is the partnerId, it's 'in', otherwise it's 'out'.
+          div.className = msg.sender_id.toString() === partnerId.toString() ? 'message-in' : 'message-out';
+          div.textContent = msg.content;
+          // Optionally, add timestamp:
+          // const small = document.createElement('small');
+          // small.textContent = new Date(msg.created_at).toLocaleTimeString();
+          // div.appendChild(small);
+          messageDisplayAreaEl.appendChild(div);
+        });
+      }
+      messageDisplayAreaEl.scrollTop = messageDisplayAreaEl.scrollHeight; // Scroll to bottom
+    } catch (err) {
+      console.error('Failed to load thread:', err);
+      messageDisplayAreaEl.innerHTML = '<p>Error loading messages.</p>';
+    }
+    replyContent.focus();
+  }
 
-  // 3) Handle compose form submit
-  form.addEventListener('submit', async e => {
+  // 4) Handle main compose form submit (for new conversations)
+  composeForm.addEventListener('submit', async e => {
     e.preventDefault();
-    errEl.textContent = '';
-    okEl.textContent  = '';
+    composeErrorEl.textContent = '';
+    composeSuccessEl.textContent  = '';
 
-    const recipientId = recipient.value;
-    const text        = content.value.trim();
+    const recipientId = recipientSelect.value;
+    const text        = composeContent.value.trim();
     if (!recipientId || !text) {
-      errEl.textContent = 'Both fields are required.';
+      composeErrorEl.textContent = 'Recipient and message text are required.';
       return;
     }
 
@@ -82,12 +123,59 @@ document.addEventListener('DOMContentLoaded', async () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ recipientId, content: text })
       });
-      if (!res.ok) throw new Error('Send failed');
-      okEl.textContent = 'Message sent!';
-      content.value    = '';
-      await loadInbox();
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: 'Send failed with no details' }));
+        throw new Error(errorData.message || 'Send failed');
+      }
+      composeSuccessEl.textContent = 'Message sent!';
+      composeContent.value    = '';
+      recipientSelect.value = ''; // Reset recipient select
+
+      // Refresh conversation list and potentially select the new/updated conversation
+      await loadConversationPartners();
+      // Try to find the user that was just messaged to auto-select the conversation
+      const selectedUser = allUsers.find(user => user.id.toString() === recipientId);
+      if (selectedUser) {
+        selectConversation(selectedUser.id, selectedUser.username);
+      }
+
     } catch (err) {
-      errEl.textContent = err.message;
+      composeErrorEl.textContent = err.message;
     }
   });
+
+  // 5) Handle reply form submit
+  replyForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    replyErrorEl.textContent = '';
+    replySuccessEl.textContent = '';
+
+    const text = replyContent.value.trim();
+    if (!text || !currentPartnerId) {
+      replyErrorEl.textContent = 'Message text is required.';
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientId: currentPartnerId, content: text })
+      });
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: 'Reply failed with no details' }));
+        throw new Error(errorData.message || 'Reply failed');
+      }
+      replySuccessEl.textContent = 'Reply sent!';
+      replyContent.value = '';
+      // Refresh the current conversation view
+      await selectConversation(currentPartnerId, currentPartnerName);
+    } catch (err) {
+      replyErrorEl.textContent = err.message;
+    }
+  });
+
+  // Initial load
+  await loadConversationPartners();
 });


### PR DESCRIPTION
- Modifies inbox.html to a two-pane structure: conversation list and selected conversation view.
- Updates inbox.js to fetch conversation partners and display full conversation threads (both sent and received messages) when a conversation is selected.
- Implements separate forms for composing new messages and replying within an active thread.
- Adds CSS for the new layout, including responsive adjustments for smaller screens.
- Leverages existing API endpoints for conversations and message threads.